### PR TITLE
Fix reruns of same commit and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.3] - 2025-05-08
 
 ### Added
 
 ### Changed
+
+- Fix reruns for same commit and nightly version when XML is not found.
 
 ### Removed
 

--- a/src/nightly.jl
+++ b/src/nightly.jl
@@ -100,7 +100,7 @@ function nightly(configfile::String = "DownstreamTester.json"; do_clone::Bool = 
                 ".github/workflows/downstreamtester.yml"
             )
             push!(new, failure)
-            info = prev
+            info = NightlyInfo(latest, string(VERSION), prev.failures)
             if failure in prev.failures
                 @info "Problem already known."
             else


### PR DESCRIPTION
This fixes the issue that tests are run even if the same commit hash and nightly version were already tested yesterday